### PR TITLE
feat: upgrade to spark 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
 
-        <scala.major.version>2.13</scala.major.version>
-        <scala.version>${scala.major.version}.11</scala.version>
+        <scala.major.version>2.12</scala.major.version>
+        <scala.version>${scala.major.version}.10</scala.version>
         <artifact.scala.version>${scala.major.version}</artifact.scala.version>
         <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
 
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
-            <version>1.2</version>
+            <version>0.13.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>2.0.3-spark-3.3-narrative0</version>
+    <version>2.0.3-spark-3.4-narrative</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -18,7 +18,7 @@
         <artifact.scala.version>${scala.major.version}</artifact.scala.version>
         <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
 
-        <spark.version>3.3.0</spark.version>
+        <spark.version>3.4.1</spark.version>
     </properties>
 
     <name>deequ</name>

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -186,14 +186,6 @@ object VerificationResult {
       }
   }
 
-  // remove private as it breaks somethingwith scala 2.13
-  // java.lang.RuntimeException: Error while encoding: java.util.concurrent.ExecutionException:
-  // org.codehaus.commons.compiler.CompileException:
-  // File 'generated.java', Line 105, Column 25: failed to compile:
-  // org.codehaus.commons.compiler.CompileException: File 'generated.java',
-  // Line 105, Column 25: No applicable constructor/method found for zero actual parameters; candidates are:
-  // "public java.lang.String com.amazon.deequ.VerificationResult$SimpleCheckResultOutput.constraintStatus()"
-  // private[this]
-  case class SimpleCheckResultOutput(checkDescription: String, checkLevel: String,
+  private[this] case class SimpleCheckResultOutput(checkDescription: String, checkLevel: String,
     checkStatus: String, constraint: String, constraintStatus: String, constraintMessage: String)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -453,7 +453,7 @@ private[deequ] object Analyzers {
     if (nullInResult) {
       None
     } else {
-      Option(func(()))
+      Option(func(Unit))
     }
   }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
@@ -52,7 +52,7 @@ class QuantileNonSample[T](
     this.shrinkingFactor = shrinkingFactor
     compactors = ArrayBuffer.fill(data.length)(new NonSampleCompactor[T])
     for (i <- data.indices) {
-      compactors(i).buffer = ArrayBuffer.from(data(i)) // data(i).to[ArrayBuffer]
+      compactors(i).buffer = data(i).to[ArrayBuffer]
     }
     curNumOfCompactors = data.length
     compactorActualSize = getCompactorItemsCount

--- a/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.aggregate.{ApproximatePercentile, DeequHyperLogLogPlusPlusUtils}
 import org.apache.spark.sql.SaveMode
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConversions._
 import scala.util.hashing.MurmurHash3
 
 private object StateInformation {
@@ -58,8 +58,7 @@ case class InMemoryStateProvider() extends StateLoader with StatePersister {
 
   override def toString: String = {
     val buffer = new StringBuilder()
-
-    statesByAnalyzer.asScala.foreach { case (analyzer, state) =>
+    statesByAnalyzer.foreach { case (analyzer, state) =>
       buffer.append(analyzer.toString)
       buffer.append(" => ")
       buffer.append(state.toString)

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
@@ -124,19 +124,13 @@ object AnalyzerContext {
     }
   }
 
-  // when using private, leads to
-  // No applicable constructor/method
-  // private[this]
-  case class SimpleMetricOutput(
+  private[this] case class SimpleMetricOutput(
     entity: String,
     instance: String,
     name: String,
     value: Double)
 
-  // when using private, leads to
-  // No applicable constructor/method
-  //  private[this]
-  object SimpleMetricOutput {
+  private[this] object SimpleMetricOutput {
 
     def apply(doubleMetric: DoubleMetric): SimpleMetricOutput = {
       SimpleMetricOutput(

--- a/src/main/scala/com/amazon/deequ/anomalydetection/OnlineNormalStrategy.scala
+++ b/src/main/scala/com/amazon/deequ/anomalydetection/OnlineNormalStrategy.scala
@@ -116,12 +116,12 @@ case class OnlineNormalStrategy(
         ret += OnlineCalculationResult(currentMean, stdDev, isAnomaly = true)
       }
     }
-    ret.toSeq
+    ret
   }
 
 
   /**
-    * Search for anomalies in a series of datag points.
+    * Search for anomalies in a series of data points.
     *
     * @param dataSeries     The data contained in a Vector of Doubles
     * @param searchInterval The indices between which anomalies should be detected. [a, b).

--- a/src/main/scala/com/amazon/deequ/anomalydetection/seasonal/HoltWinters.scala
+++ b/src/main/scala/com/amazon/deequ/anomalydetection/seasonal/HoltWinters.scala
@@ -132,7 +132,7 @@ class HoltWinters(
       }
     val forecasted = Y.drop(series.size)
 
-    ModelResults(forecasted.toSeq, level.toSeq, trend.toSeq, seasonality.toSeq, residuals.toSeq)
+    ModelResults(forecasted, level, trend, seasonality, residuals)
   }
 
   private def modelSelectionFor(

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -347,7 +347,7 @@ object ColumnProfiler {
                   Histogram(histogram.column).equals(histogram)
               case _ => false
             }
-          analyzerContextExistingValues = AnalyzerContext(relevantEntries.toMap)
+          analyzerContextExistingValues = AnalyzerContext(relevantEntries)
         }
       }
     }

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -27,13 +27,14 @@ import com.google.gson._
 import com.google.gson.reflect.TypeToken
 
 import scala.collection._
+import scala.collection.JavaConverters._
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 import JsonSerializationConstants._
 import com.amazon.deequ.analyzers.Histogram.{AggregateFunction, Count => HistogramCount, Sum => HistogramSum}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.expr
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConversions._
 
 private[repository] object JsonSerializationConstants {
 
@@ -69,7 +70,6 @@ private[deequ] object SimpleResultSerde {
       .asInstanceOf[JArrayList[JMap[String, String]]]
       .asScala
       .map(map => immutable.Map(map.asScala.toList: _*))
-      .toSeq
   }
 }
 
@@ -422,22 +422,22 @@ private[deequ] object AnalyzerDeserializer
           getOptionalWhereParam(json))
 
       case "CountDistinct" =>
-        CountDistinct(getColumnsAsSeq(context, json).toSeq)
+        CountDistinct(getColumnsAsSeq(context, json))
 
       case "Distinctness" =>
-        Distinctness(getColumnsAsSeq(context, json).toSeq)
+        Distinctness(getColumnsAsSeq(context, json))
 
       case "Entropy" =>
         Entropy(json.get(COLUMN_FIELD).getAsString)
 
       case "MutualInformation" =>
-        MutualInformation(getColumnsAsSeq(context, json).toSeq)
+        MutualInformation(getColumnsAsSeq(context, json))
 
       case "UniqueValueRatio" =>
-        UniqueValueRatio(getColumnsAsSeq(context, json).toSeq)
+        UniqueValueRatio(getColumnsAsSeq(context, json))
 
       case "Uniqueness" =>
-        Uniqueness(getColumnsAsSeq(context, json).toSeq)
+        Uniqueness(getColumnsAsSeq(context, json))
 
       case "Histogram" =>
         Histogram(
@@ -598,7 +598,7 @@ private[deequ] object MetricDeserializer extends JsonDeserializer[Metric[_]] {
         val instance = jsonObject.get("instance").getAsString
         if (jsonObject.has("value")) {
           val entries = jsonObject.get("value").getAsJsonObject
-          val values = entries.entrySet().asScala.map { entry =>
+          val values = entries.entrySet().map { entry =>
             entry.getKey -> entry.getValue.getAsDouble
           }
           .toMap

--- a/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
+++ b/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
@@ -99,8 +99,8 @@ private[repository] object MetricsRepositoryMultipleResultsLoader {
 
   def jsonUnion(jsonOne: String, jsonTwo: String): String = {
 
-    val objectOne: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonOne).toSeq
-    val objectTwo: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonTwo).toSeq
+    val objectOne: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonOne)
+    val objectTwo: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonTwo)
 
     val columnsTotal = objectOne.headOption.getOrElse(Map.empty).keySet ++
       objectTwo.headOption.getOrElse(Map.empty).keySet

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -153,11 +153,10 @@ class FileSystemMetricsRepositoryMultipleResultsLoader(
           .metricMap
           .filterKeys(analyzer => forAnalyzers.isEmpty || forAnalyzers.get.contains(analyzer))
 
-        val requestedAnalyzerContext = AnalyzerContext(requestedMetrics.toMap)
+        val requestedAnalyzerContext = AnalyzerContext(requestedMetrics)
 
         AnalysisResult(analysisResult.resultKey, requestedAnalyzerContext)
       }
-      .toSeq
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConversions._
 import java.util.concurrent.ConcurrentHashMap
 
 /** A simple Repository implementation backed by a concurrent hash map */
@@ -118,7 +118,6 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
   /** Get the AnalysisResult */
   def get(): Seq[AnalysisResult] = {
     resultsRepository
-      .asScala
       .filterKeys(key => after.isEmpty || after.get <= key.dataSetDate)
       .filterKeys(key => before.isEmpty || key.dataSetDate <= before.get)
       .filterKeys(key => tagValues.isEmpty || tagValues.get.toSet.subsetOf(key.tags.toSet))
@@ -130,7 +129,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
           .metricMap
           .filterKeys(analyzer => forAnalyzers.isEmpty || forAnalyzers.get.contains(analyzer))
 
-        AnalysisResult(analysisResult.resultKey, AnalyzerContext(requestedMetrics.toMap))
+        AnalysisResult(analysisResult.resultKey, AnalyzerContext(requestedMetrics))
       }
       .toSeq
   }

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -142,7 +142,7 @@ class ConstraintSuggestionRunner {
         groupedSuggestionsWithColumnNames.map { case (_, suggestion) => suggestion } }
 
     ConstraintSuggestionResult(columnProfiles.profiles, columnProfiles.numRecords,
-      columnsWithSuggestions.toMap, verificationResult)
+      columnsWithSuggestions, verificationResult)
   }
 
   private[this] def splitTrainTestSets(

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -88,7 +88,7 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
     val sample2 = scala.collection.mutable.Map(
       "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
     val distance = Distance.categoricalDistance(sample1, sample2, method = LInfinityMethod(alpha = Some(0.003)))
-    assert(distance == 0.27263380465503484)
+    assert(distance == 0.2726338046550349)
   }
 
   "Categorial distance should compute correct linf_robust with different alpha value .1" in {
@@ -137,7 +137,7 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
       "a" -> 100L, "b" -> 22L, "c" -> 25L, "d" -> 5L, "e" -> 13L, "f" -> 2L)
     val distance = Distance.categoricalDistance(
       sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod())
-    assert(distance == 8.789790456457123)
+    assert(distance == 8.789790456457125)
   }
 
   "Categorical distance should compute correct chisquare distance (low samples) with regrouping (yates)" in {
@@ -170,7 +170,7 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L, "e" -> 20L, "f" -> 20L, "g" -> 20L, "h" -> 20L)
     val distance = Distance.categoricalDistance(
       sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod())
-    assert(distance == 6.827423492761592)
+    assert(distance == 6.827423492761593)
   }
 
   "Categorical distance should compute correct chisquare distance (low samples) " +

--- a/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
@@ -79,13 +79,12 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
           val successMetricsResultsJson = VerificationResult.successMetricsAsJson(results)
 
           val expectedJson =
-            """[
-              |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25},
-              {"entity":"Column","instance":"item","name":"Distinctness","value":1.0},
+            """[{"entity":"Column","instance":"item","name":"Distinctness","value":1.0},
               |{"entity": "Column", "instance":"att2","name":"Completeness","value":1.0},
-              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0}
-              |]"""
+              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
+              |{"entity":"Multicolumn","instance":"att1,att2",
+              |"name":"Uniqueness","value":0.25},
+              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0}]"""
               .stripMargin.replaceAll("\n", "")
 
           assertSameResultsJson(successMetricsResultsJson, expectedJson)
@@ -103,10 +102,9 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
             VerificationResult.successMetricsAsJson(results, metricsForAnalyzers)
 
           val expectedJson =
-            """[
-              |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0}
-              |]"""
+            """[{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
+              |{"entity":"Multicolumn","instance":"att1,att2",
+              |"name":"Uniqueness","value":0.25}]"""
               .stripMargin.replaceAll("\n", "")
 
            assertSameResultsJson(successMetricsResultsJson, expectedJson)

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -17,7 +17,6 @@
 package com.amazon.deequ
 package analyzers
 
-import com.amazon.deequ
 import com.amazon.deequ.analyzers.runners.NoSuchColumnException
 import com.amazon.deequ.metrics.Distribution
 import com.amazon.deequ.metrics.DistributionValue
@@ -350,7 +349,6 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
       val dataTypes = DataTypeInstances.values.map { _.toString }
 
       val zeros = dataTypes
-        .unsorted
         .diff { nonZeroValuesWithStringKeys.map { case (distKey, _) => distKey }.toSet }
         .map(dataType => dataType -> DistributionValue(0, 0.0))
         .toSeq
@@ -363,33 +361,33 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
     "fail for non-atomic columns" in withSparkSession { sparkSession =>
       val df = getDfWithNestedColumn(sparkSession)
 
-      assert(deequ.analyzers.DataType("source").calculate(df).value.isFailure)
+      assert(DataType("source").calculate(df).value.isFailure)
     }
 
     "fall back to String in case no known data type matched" in withSparkSession { sparkSession =>
       val df = getDfFull(sparkSession)
 
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe
+      DataType("att1").calculate(df).value shouldBe
         Success(distributionFrom(DataTypeInstances.String -> DistributionValue(4, 1.0)))
     }
 
     "detect integral type correctly" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
       val expectedResult = distributionFrom(DataTypeInstances.Integral -> DistributionValue(6, 1.0))
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att1").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "detect integral type correctly for negative numbers" in withSparkSession { sparkSession =>
       val df = getDfWithNegativeNumbers(sparkSession)
       val expectedResult = distributionFrom(DataTypeInstances.Integral -> DistributionValue(4, 1.0))
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att1").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "detect fractional type correctly for negative numbers" in withSparkSession { sparkSession =>
       val df = getDfWithNegativeNumbers(sparkSession)
       val expectedResult =
         distributionFrom(DataTypeInstances.Fractional -> DistributionValue(4, 1.0))
-      deequ.analyzers.DataType("att2").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att2").calculate(df).value shouldBe Success(expectedResult)
     }
 
 
@@ -398,14 +396,14 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
         .withColumn("att1_float", col("att1").cast(FloatType))
       val expectedResult =
         distributionFrom(DataTypeInstances.Fractional -> DistributionValue(6, 1.0))
-        deequ.analyzers.DataType("att1_float").calculate(df).value shouldBe Success(expectedResult)
+        DataType("att1_float").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "detect integral type in string column" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
         .withColumn("att1_str", col("att1").cast(StringType))
       val expectedResult = distributionFrom(DataTypeInstances.Integral -> DistributionValue(6, 1.0))
-      deequ.analyzers.DataType("att1_str").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att1_str").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "detect fractional type in string column" in withSparkSession { sparkSession =>
@@ -414,19 +412,19 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
       val expectedResult =
         distributionFrom(DataTypeInstances.Fractional -> DistributionValue(6, 1.0))
-      deequ.analyzers.DataType("att1_str").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att1_str").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "fall back to string in case the string column didn't match " +
       " any known other data type" in withSparkSession { sparkSession =>
       val df = getDfFull(sparkSession)
       val expectedResult = distributionFrom(DataTypeInstances.String -> DistributionValue(4, 1.0))
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att1").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "detect fractional for mixed fractional and integral" in withSparkSession { sparkSession =>
       val df = getDfFractionalIntegralTypes(sparkSession)
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(
+      DataType("att1").calculate(df).value shouldBe Success(
         distributionFrom(
           DataTypeInstances.Fractional -> DistributionValue(1, 0.5),
           DataTypeInstances.Integral -> DistributionValue(1, 0.5)
@@ -436,7 +434,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
     "fall back to string for mixed fractional and string" in withSparkSession { sparkSession =>
       val df = getDfFractionalStringTypes(sparkSession)
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(
+      DataType("att1").calculate(df).value shouldBe Success(
         distributionFrom(
           DataTypeInstances.Fractional -> DistributionValue(1, 0.5),
           DataTypeInstances.String -> DistributionValue(1, 0.5)
@@ -446,7 +444,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
     "fall back to string for mixed integral and string" in withSparkSession { sparkSession =>
       val df = getDfIntegralStringTypes(sparkSession)
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(
+      DataType("att1").calculate(df).value shouldBe Success(
         distributionFrom(
           DataTypeInstances.Integral -> DistributionValue(1, 0.5),
           DataTypeInstances.String -> DistributionValue(1, 0.5)
@@ -456,7 +454,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
     "integral for numeric and null" in withSparkSession { sparkSession =>
       val df = getDfWithUniqueColumns(sparkSession)
-      deequ.analyzers.DataType("uniqueWithNulls").calculate(df).value shouldBe Success(
+      DataType("uniqueWithNulls").calculate(df).value shouldBe Success(
         distributionFrom(
           DataTypeInstances.Unknown -> DistributionValue(1, 1.0/6.0),
           DataTypeInstances.Integral -> DistributionValue(5, 5.0/6.0)
@@ -473,7 +471,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
       val expectedResult = distributionFrom(DataTypeInstances.Boolean -> DistributionValue(2, 1.0))
 
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(expectedResult)
+      DataType("att1").calculate(df).value shouldBe Success(expectedResult)
     }
 
     "fall back to string for boolean and null" in withSparkSession { sparkSession =>
@@ -485,7 +483,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
         ("4", "2.0")
       ).toDF("item", "att1")
 
-      deequ.analyzers.DataType("att1").calculate(df).value shouldBe Success(
+      DataType("att1").calculate(df).value shouldBe Success(
         distributionFrom(
           DataTypeInstances.Fractional -> DistributionValue(1, 0.25),
           DataTypeInstances.Unknown -> DistributionValue(1, 0.25),

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -184,13 +184,12 @@ class AnalysisRunnerTests extends AnyWordSpec
           Uniqueness("att1", Some("att3 = 0")) :: Nil
 
         val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
-          val results: Seq[com.amazon.deequ.metrics.DoubleMetric] =
-            analyzers.map { _.calculate(df) }.toSeq.sortBy(_.name)
+          val results = analyzers.map { _.calculate(df) }.toSet
           (results, stat.jobCount)
         }
 
         val (runnerResults, numCombinedJobs) = sparkMonitor.withMonitoringSession { stat =>
-          val results = AnalysisRunner.onData(df).addAnalyzers(analyzers).run().allMetrics.toSeq.sortBy(_.name)
+          val results = AnalysisRunner.onData(df).addAnalyzers(analyzers).run().allMetrics.toSet
           (results, stat.jobCount)
         }
 

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
@@ -81,20 +81,20 @@ class AnalyzerContextTest extends AnyWordSpec
 
           val successMetricsResultsJson = AnalyzerContext.successMetricsAsJson(results)
 
-            val expectedJson =
-              """[
-                |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25},
-                |{"entity":"Dataset","instance":"*","name":"Size (where: att2 == 'd')","value":1.0},
-                |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0},
-                |{"entity":"Column","instance":"att1","name":"Histogram.bins","value":2.0},
-                |{"entity":"Column","instance":"att1","name":"Histogram.abs.a","value":3.0},
-                |{"entity":"Column","instance":"att1","name":"Histogram.ratio.a","value":0.75},
-                |{"entity":"Column","instance":"att1","name":"Histogram.abs.b","value":1.0},
-                |{"entity":"Column","instance":"att1","name":"Histogram.ratio.b","value":0.25},
-                |{"entity":"Dataset","instance":"*","name":"Size","value":4.0},
-                |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0}
-                |]"""
-                .stripMargin.replaceAll("\n", "")
+          val expectedJson =
+            """[
+              |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0},
+              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
+              |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25},
+              |{"entity":"Dataset","instance":"*","name":"Size (where: att2 == 'd')","value":1.0},
+              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0},
+              |{"entity":"Column","instance":"att1","name":"Histogram.bins","value":2.0},
+              |{"entity":"Column","instance":"att1","name":"Histogram.abs.a","value":3.0},
+              |{"entity":"Column","instance":"att1","name":"Histogram.ratio.a","value":0.75},
+              |{"entity":"Column","instance":"att1","name":"Histogram.abs.b","value":1.0},
+              |{"entity":"Column","instance":"att1","name":"Histogram.ratio.b","value":0.25}
+              |]"""
+              .stripMargin.replaceAll("\n", "")
 
           assertSameJson(successMetricsResultsJson, expectedJson)
         }
@@ -110,11 +110,10 @@ class AnalyzerContextTest extends AnyWordSpec
           val successMetricsResultsJson =
             AnalyzerContext.successMetricsAsJson(results, metricsForAnalyzers)
 
-           val expectedJson =
-            """[
-              |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0}
-              |]"""
+          val expectedJson =
+            """[{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
+              |{"entity":"Multicolumn","instance":"att1,att2",
+              |"name":"Uniqueness","value":0.25}]"""
             .stripMargin.replaceAll("\n", "")
 
           assertSameJson(successMetricsResultsJson, expectedJson)

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -333,22 +333,21 @@ class SimpleResultSerdeTest extends WordSpec with Matchers with SparkContextSpec
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
           |"instance":"att2","name":"Completeness","value":1.0},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
-          |"instance":"att1","name":"MaxLength","value":1.0},
-          |{"dataset_date":1507975810,"entity":"Column","region":"EU",
-          |"instance":"att1","name":"MinLength","value":1.0},
+          |"instance":"att1","name":"Completeness","value":1.0},
+          |{"dataset_date":1507975810,"entity":"Multicolumn","region":"EU",
+          |"instance":"att1,att2","name":"MutualInformation","value":0.5623351446188083},
+          |{"dataset_date":1507975810,"entity":"Dataset","region":"EU",
+          |"instance":"*","name":"Size","value":4.0},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
           |"instance":"att1","name":"Uniqueness","value":0.25},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
           |"instance":"att1","name":"Distinctness","value":0.5},
-          |{"dataset_date":1507975810,"entity":"Multicolumn","region":"EU",
-          |"instance":"att1,att2","name":"MutualInformation","value":0.5623351446188083},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
-          |"instance":"att2","name":"Uniqueness","value":0.25},
-          |{"dataset_date":1507975810,"entity":"Dataset","region":"EU",
-          |"instance":"*","name":"Size","value":4.0},
+          |"instance":"att1","name":"MinLength","value":1.0},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
-          |"instance":"att1","name":"Completeness","value":1.0}
-          |]"""
+          |"instance":"att1","name":"MaxLength","value":1.0},
+          |{"dataset_date":1507975810,"entity":"Column","region":"EU",
+          |"instance":"att2","name":"Uniqueness","value":0.25}]"""
             .stripMargin.replaceAll("\n", "")
 
       // ordering of map entries is not guaranteed, so comparing strings is not an option

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
@@ -81,17 +81,8 @@ class MetricsRepositoryMultipleResultsLoaderTest extends AnyWordSpec with Matche
           val analysisResultsAsJson = repository.load()
             .getSuccessMetricsAsJson()
 
-            val expected =
-              s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
-              |"region":"NA", "dataset_date":$DATE_TWO},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
-              |"region":"NA", "dataset_date":$DATE_TWO},
-              |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
-              |"region":"NA", "dataset_date":$DATE_TWO},
-              |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25,
-              |"region":"NA", "dataset_date":$DATE_TWO},
-              |
-              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
+          val expected =
+            s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
               |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
@@ -99,8 +90,17 @@ class MetricsRepositoryMultipleResultsLoaderTest extends AnyWordSpec with Matche
               |"region":"EU", "dataset_date":$DATE_ONE},
               |{"entity":"Multicolumn","instance":"att1,att2",
               |"name":"Uniqueness","value":0.25,
-              |"region":"EU", "dataset_date":$DATE_ONE}]"""
-                .stripMargin.replaceAll("\n", "")
+              |"region":"EU", "dataset_date":$DATE_ONE},
+              |
+              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
+              |"region":"NA", "dataset_date":$DATE_TWO},
+              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |"region":"NA", "dataset_date":$DATE_TWO},
+              |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
+              |"region":"NA", "dataset_date":$DATE_TWO},
+              |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25,
+              |"region":"NA", "dataset_date":$DATE_TWO}]"""
+              .stripMargin.replaceAll("\n", "")
 
           assertSameJson(analysisResultsAsJson, expected)
         }


### PR DESCRIPTION
Will not be merged, for posterity only.

Upgrading to EMR 6.13.0 brings in Spark 3.4.1 which depends on `org.scala-lang.modules:scala-parser-combinators_2.12:2.1.1` which is binary incompatible with the version used by Spark 3.3.x (`1.1.2`). Deequ uses Spark 3.3.x so rather than try to exclude dependencies from the version of Deequ on which we rely it's easier to just get it upgraded.

FWIW awslabs/deequ has an open PR that bumps Spark to 3.4.1 that hasn't gotten any feedback in two weeks. Rather than wait on AWS to merge that down, we'll live with using a fork for now.

Version published as `2.0.3-spark-3.4-narrative` to our S3 artifactory.